### PR TITLE
Add support for publishing and consuming messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "rabbitmq_http_client"
 version = "0.6.0"
-source = "git+https://github.com/michaelklishin/rabbitmq-http-api-rs#f25ff304b5e8db50cb5c3094b9d607a1e032b563"
+source = "git+https://github.com/michaelklishin/rabbitmq-http-api-rs#925758f8856d6f35587a9678007329e35538096a"
 dependencies = [
  "percent-encoding",
  "rand",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -227,6 +227,14 @@ pub fn parser() -> Command {
                 .about("import definitions")
                 .subcommand_value_name("definitions")
                 .subcommands(import_subcommands()),
+            Command::new("publish")
+                .about("publish a message")
+                .subcommand_value_name("message")
+                .subcommands(publish_subcommands()),
+            Command::new("get")
+                .about("get message(s) from a queue")
+                .subcommand_value_name("message")
+                .subcommands(get_subcommands()),
         ])
 }
 
@@ -731,5 +739,70 @@ fn import_subcommands() -> [Command; 1] {
                 .long("file")
                 .help("JSON file with definitions")
                 .required(true),
+        )]
+}
+
+pub fn publish_subcommands() -> [Command; 1] {
+    [Command::new("message")
+        .about("Publishes a message to an exchange")
+        .arg(
+            Arg::new("routing-key")
+                .short('k')
+                .long("routing-key")
+                .required(false)
+                .default_value("")
+                .help("Name of virtual host"),
+        )
+        .arg(
+            Arg::new("exchange")
+                .short('e')
+                .long("exchange")
+                .required(false)
+                .default_value("")
+                .help("Exchange name (defaults to empty)"),
+        )
+        .arg(
+            Arg::new("payload")
+                .short('m')
+                .long("payload")
+                .required(false)
+                .default_value("test")
+                .help("Message payload/body"),
+        )
+        .arg(
+            Arg::new("properties")
+                .short('p')
+                .long("properties")
+                .required(false)
+                .default_value("{}")
+                .help("Message properties"),
+        )]
+}
+
+pub fn get_subcommands() -> [Command; 1] {
+    [Command::new("messages")
+        .about("Consumes message(s) from a queue")
+        .arg(
+            Arg::new("queue")
+                .short('q')
+                .long("queue")
+                .required(true)
+                .help("Queue name"),
+        )
+        .arg(
+            Arg::new("count")
+                .short('c')
+                .long("count")
+                .required(false)
+                .default_value("1")
+                .help("Maximum number of messages to consume"),
+        )
+        .arg(
+            Arg::new("ack-mode")
+                .short('a')
+                .long("ack-mode")
+                .required(false)
+                .default_value("ack_requeue_false")
+                .help("ack_requeue_false, reject_requeue_false, ack_requeue_true or reject_requeue_true"),
         )]
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -542,3 +542,32 @@ pub fn import_definitions(client: APIClient, command_args: &ArgMatches) -> Clien
         }
     }
 }
+
+pub fn publish_message(
+    client: APIClient,
+    vhost: &str,
+    command_args: &ArgMatches,
+) -> ClientResult<responses::MessageRouted> {
+    let exchange = command_args.get_one::<String>("exchange").unwrap();
+    let routing_key = command_args.get_one::<String>("routing-key").unwrap();
+    let payload = command_args.get_one::<String>("payload").unwrap();
+    let properties = command_args.get_one::<String>("properties").unwrap();
+    let parsed_properties = serde_json::from_str::<requests::MessageProperties>(properties)
+        .unwrap_or_else(|err| {
+            eprintln!("`{}` is not a valid JSON: {}", properties, err);
+            process::exit(1);
+        });
+
+    client.publish_message(vhost, exchange, routing_key, payload, parsed_properties)
+}
+
+pub fn get_messages(
+    client: APIClient,
+    vhost: &str,
+    command_args: &ArgMatches,
+) -> ClientResult<Vec<responses::GetMessage>> {
+    let queue = command_args.get_one::<String>("queue").unwrap();
+    let count = command_args.get_one::<String>("count").unwrap();
+    let ack_mode = command_args.get_one::<String>("ack-mode").unwrap();
+    client.get_messages(vhost, queue, count.parse::<u32>().unwrap(), ack_mode)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,11 +226,19 @@ fn main() {
                 }
                 ("export", "definitions") => {
                     let result = commands::export_definitions(client, command_args);
-                    print_result_or_fail(result);
+                    print_debug_result_or_fail(result);
                 }
                 ("import", "definitions") => {
                     let result = commands::import_definitions(client, command_args);
+                    print_debug_result_or_fail(result);
+                }
+                ("publish", "message") => {
+                    let result = commands::publish_message(client, &sf.virtual_host, command_args);
                     print_result_or_fail(result);
+                }
+                ("get", "messages") => {
+                    let result = commands::get_messages(client, &sf.virtual_host, command_args);
+                    print_table_or_fail(result);
                 }
                 _ => {
                     println!("Unknown command and subcommand pair: {:?}", &pair);
@@ -258,7 +266,19 @@ where
     }
 }
 
-fn print_result_or_fail<T: fmt::Debug>(result: Result<T, rabbitmq_http_client::blocking::Error>) {
+fn print_result_or_fail<T: fmt::Display>(result: Result<T, rabbitmq_http_client::blocking::Error>) {
+    match result {
+        Ok(output) => println!("{}", output),
+        Err(error) => {
+            eprintln!("{}", error.source().unwrap_or(&error),);
+            process::exit(1)
+        }
+    }
+}
+
+fn print_debug_result_or_fail<T: fmt::Debug>(
+    result: Result<T, rabbitmq_http_client::blocking::Error>,
+) {
     match result {
         Ok(output) => println!("{:?}", output),
         Err(error) => {


### PR DESCRIPTION
This is the current experience
```
> rabbitmqadmin publish message
Message published but NOT routed

> rabbitmqadmin publish message --routing-key cq
Message published and routed successfully

> rabbitmqadmin get messages --queue cq
┌───────────────┬─────────────┬──────────┬─────────────┬───────────────┬────────────┬─────────┬──────────────────┐
│ payload_bytes │ redelivered │ exchange │ routing_key │ message_count │ properties │ payload │ payload_encoding │
├───────────────┼─────────────┼──────────┼─────────────┼───────────────┼────────────┼─────────┼──────────────────┤
│ 4             │ false       │          │ cq          │ 0             │            │ test    │ string           │
└───────────────┴─────────────┴──────────┴─────────────┴───────────────┴────────────┴─────────┴──────────────────┘
```

I'm not 100% about the (sub)command names (`publish message` and `get messages`) but can't find anything better. Perhaps we should drop the `message`/`messages`?