### PR TITLE
Define --vhost for individual commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,6 +266,15 @@ pub fn parser() -> Command {
 }
 
 fn list_subcommands() -> [Command; 15] {
+    // duplicate this very common global argument so that
+    // it can be passed as the end of argument list
+    let vhost_arg = Arg::new("vhost")
+        .short('V')
+        .long("vhost")
+        .help("target virtual host")
+        .required(false)
+        .default_value(DEFAULT_VHOST);
+
     [
         Command::new("nodes").long_about("Lists cluster members"),
         Command::new("users").long_about("Lists users in the internal database"),
@@ -275,33 +284,39 @@ fn list_subcommands() -> [Command; 15] {
                 "<bold>Doc guide</bold>: https://rabbitmq.com/vhosts.html"
             )),
         Command::new("permissions")
+            .arg(vhost_arg.clone())
             .long_about("Lists user permissions")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/access-control.html"
             )),
         Command::new("connections")
+            .arg(vhost_arg.clone())
             .long_about("Lists client connections")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/connections.html"
             )),
         Command::new("channels")
+            .arg(vhost_arg.clone())
             .long_about("Lists AMQP 0-9-1 channels")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/channels.html"
             )),
         Command::new("queues")
+            .arg(vhost_arg.clone())
             .long_about("Lists queues")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/queues.html"
             )),
-        Command::new("exchanges"),
-        Command::new("bindings"),
+        Command::new("exchanges").arg(vhost_arg.clone()),
+        Command::new("bindings").arg(vhost_arg.clone()),
         Command::new("consumers")
+            .arg(vhost_arg.clone())
             .long_about("Lists consumers")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/consumers.html"
             )),
         Command::new("parameters")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("component")
                     .long("component")
@@ -313,21 +328,25 @@ fn list_subcommands() -> [Command; 15] {
                 "<bold>Doc guide</bold>: https://rabbitmq.com/parameters.html"
             )),
         Command::new("policies")
+            .arg(vhost_arg.clone())
             .long_about("Lists policies")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/parameters.html"
             )),
         Command::new("operator_policies")
+            .arg(vhost_arg.clone())
             .long_about("Lists operator policies")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/parameters.html"
             )),
         Command::new("vhost_limits")
+            .arg(vhost_arg.clone())
             .long_about("Lists virtual host (resource) limits")
             .after_long_help(color_print::cstr!(
                 "<bold>Doc guide</bold>: https://rabbitmq.com/vhosts.html"
             )),
         Command::new("user_limits")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("user")
                     .long("user")
@@ -342,6 +361,15 @@ fn list_subcommands() -> [Command; 15] {
 }
 
 fn declare_subcommands() -> [Command; 11] {
+    // duplicate this very common global argument so that
+    // it can be passed as the end of argument list
+    let vhost_arg = Arg::new("vhost")
+        .short('V')
+        .long("vhost")
+        .help("target virtual host")
+        .required(false)
+        .default_value(DEFAULT_VHOST);
+
     [
         Command::new("user")
             .about("creates a user")
@@ -401,6 +429,7 @@ fn declare_subcommands() -> [Command; 11] {
             ),
         Command::new("permissions")
             .about("grants permissions to a user")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("user")
                     .long("user")
@@ -427,6 +456,7 @@ fn declare_subcommands() -> [Command; 11] {
             ),
         Command::new("queue")
             .about("declares a queue")
+            .arg(vhost_arg.clone())
             .arg(Arg::new("name").long("name").required(true).help("name"))
             .arg(
                 Arg::new("type")
@@ -459,6 +489,7 @@ fn declare_subcommands() -> [Command; 11] {
             ),
         Command::new("exchange")
             .about("declares an exchange")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -495,6 +526,7 @@ fn declare_subcommands() -> [Command; 11] {
             ),
         Command::new("binding")
             .about("binds to an exchange")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("source")
                     .long("source")
@@ -529,14 +561,14 @@ fn declare_subcommands() -> [Command; 11] {
                     .value_parser(clap::value_parser!(String)),
             ),
         Command::new("parameter").
-            about("sets a runtime parameter").
-            arg(
+            about("sets a runtime parameter")
+            .arg(vhost_arg.clone())
+            .arg(
                 Arg::new("name")
                     .long("name")
                     .help("parameter's name")
                     .required(true)
-            ).
-            arg(
+            ).arg(
                 Arg::new("component")
                     .long("component")
                     .help("component (eg. federation)")
@@ -548,6 +580,7 @@ fn declare_subcommands() -> [Command; 11] {
                     .required(true)),
         Command::new("policy")
             .about("creates or updates a policy")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -579,7 +612,9 @@ fn declare_subcommands() -> [Command; 11] {
                     .help("policy definition")
                     .required(true),
             ),
-        Command::new("operator_policy").about("creates or updates an operator policy")
+        Command::new("operator_policy")
+            .about("creates or updates an operator policy")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -611,7 +646,9 @@ fn declare_subcommands() -> [Command; 11] {
                     .help("policy definition")
                     .required(true),
             ),
-        Command::new("vhost_limit").about("set a vhost limit")
+        Command::new("vhost_limit")
+            .about("set a vhost limit")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -653,6 +690,15 @@ fn show_subcomands() -> [Command; 1] {
 }
 
 fn delete_subcommands() -> [Command; 11] {
+    // duplicate this very common global argument so that
+    // it can be passed as the end of argument list
+    let vhost_arg = Arg::new("vhost")
+        .short('V')
+        .long("vhost")
+        .help("target virtual host")
+        .required(false)
+        .default_value(DEFAULT_VHOST);
+
     [
         Command::new("user").about("deletes a user").arg(
             Arg::new("name")
@@ -668,6 +714,7 @@ fn delete_subcommands() -> [Command; 11] {
         ),
         Command::new("permissions")
             .about("revokes user permissions to a given vhost")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("user")
                     .long("user")
@@ -676,15 +723,20 @@ fn delete_subcommands() -> [Command; 11] {
             ),
         Command::new("queue")
             .about("deletes a queue")
+            .arg(vhost_arg.clone())
             .arg(Arg::new("name").long("name").help("queue").required(true)),
-        Command::new("exchange").about("deletes an exchange").arg(
-            Arg::new("name")
-                .long("name")
-                .help("exchange")
-                .required(true),
-        ),
+        Command::new("exchange")
+            .about("deletes an exchange")
+            .arg(vhost_arg.clone())
+            .arg(
+                Arg::new("name")
+                    .long("name")
+                    .help("exchange")
+                    .required(true),
+            ),
         Command::new("binding")
             .about("deletes a binding")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("source")
                     .long("source")
@@ -719,6 +771,7 @@ fn delete_subcommands() -> [Command; 11] {
             ),
         Command::new("parameter")
             .about("clears a runtime parameter")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -731,14 +784,18 @@ fn delete_subcommands() -> [Command; 11] {
                     .help("component (eg. federation-upstream)")
                     .required(true),
             ),
-        Command::new("policy").about("deletes a policy").arg(
-            Arg::new("name")
-                .long("name")
-                .help("policy name")
-                .required(true),
-        ),
+        Command::new("policy")
+            .about("deletes a policy")
+            .arg(vhost_arg.clone())
+            .arg(
+                Arg::new("name")
+                    .long("name")
+                    .help("policy name")
+                    .required(true),
+            ),
         Command::new("operator_policy")
             .about("deletes an operator policy")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")
@@ -747,6 +804,7 @@ fn delete_subcommands() -> [Command; 11] {
             ),
         Command::new("vhost_limit")
             .about("delete a vhost limit")
+            .arg(vhost_arg.clone())
             .arg(
                 Arg::new("name")
                     .long("name")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use clap::ArgMatches;
 use std::fmt;
 use std::fs::File;
 use std::io::Read;
@@ -12,6 +13,7 @@ mod commands;
 mod constants;
 
 use crate::cli::SharedFlags;
+use crate::constants::DEFAULT_VHOST;
 use rabbitmq_http_client::blocking::Client as APIClient;
 
 fn main() {
@@ -56,6 +58,8 @@ fn main() {
         if let Some((kind, command_args)) = group_args.subcommand() {
             let pair = (verb, kind);
 
+            let vhost = virtual_host(&sf, command_args);
+
             match &pair {
                 ("list", "nodes") => {
                     let result = commands::list_nodes(client);
@@ -66,7 +70,7 @@ fn main() {
                     print_table_or_fail(result);
                 }
                 ("list", "vhost_limits") => {
-                    let result = commands::list_vhost_limits(client, &sf.virtual_host);
+                    let result = commands::list_vhost_limits(client, &vhost);
                     print_table_or_fail(result);
                 }
                 ("list", "user_limits") => {
@@ -98,7 +102,7 @@ fn main() {
                     print_table_or_fail(result);
                 }
                 ("list", "queues") => {
-                    let result = commands::list_queues(client, &sf.virtual_host);
+                    let result = commands::list_queues(client, &vhost);
                     print_table_or_fail(result);
                 }
                 ("list", "bindings") => {
@@ -110,11 +114,11 @@ fn main() {
                     print_table_or_fail(result);
                 }
                 ("list", "parameters") => {
-                    let result = commands::list_parameters(client, &sf.virtual_host, command_args);
+                    let result = commands::list_parameters(client, &vhost, command_args);
                     print_table_or_fail(result);
                 }
                 ("list", "exchanges") => {
-                    let result = commands::list_exchanges(client, &sf.virtual_host);
+                    let result = commands::list_exchanges(client, &vhost);
                     print_table_or_fail(result);
                 }
                 ("declare", "vhost") => {
@@ -122,7 +126,7 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("declare", "exchange") => {
-                    let result = commands::declare_exchange(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_exchange(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "user") => {
@@ -130,35 +134,31 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("declare", "permissions") => {
-                    let result =
-                        commands::declare_permissions(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_permissions(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "permissions") => {
-                    let result =
-                        commands::delete_permissions(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_permissions(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "queue") => {
-                    let result = commands::declare_queue(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_queue(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "binding") => {
-                    let result = commands::declare_binding(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_binding(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "policy") => {
-                    let result = commands::declare_policy(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_policy(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "operator_policy") => {
-                    let result =
-                        commands::declare_operator_policy(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_operator_policy(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "vhost_limit") => {
-                    let result =
-                        commands::declare_vhost_limit(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_vhost_limit(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("declare", "user_limit") => {
@@ -166,8 +166,7 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("declare", "parameter") => {
-                    let result =
-                        commands::declare_parameter(client, &sf.virtual_host, command_args);
+                    let result = commands::declare_parameter(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "vhost") => {
@@ -175,7 +174,7 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("delete", "exchange") => {
-                    let result = commands::delete_exchange(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_exchange(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "user") => {
@@ -183,25 +182,23 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("delete", "queue") => {
-                    let result = commands::delete_queue(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_queue(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "binding") => {
-                    let result = commands::delete_binding(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_binding(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "policy") => {
-                    let result = commands::delete_policy(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_policy(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "operator_policy") => {
-                    let result =
-                        commands::delete_operator_policy(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_operator_policy(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "vhost_limit") => {
-                    let result =
-                        commands::delete_vhost_limit(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_vhost_limit(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("delete", "user_limit") => {
@@ -209,11 +206,11 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("delete", "parameter") => {
-                    let result = commands::delete_parameter(client, &sf.virtual_host, command_args);
+                    let result = commands::delete_parameter(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("purge", "queue") => {
-                    let result = commands::purge_queue(client, &sf.virtual_host, command_args);
+                    let result = commands::purge_queue(client, &vhost, command_args);
                     print_nothing_or_fail(result);
                 }
                 ("rebalance", "queues") => {
@@ -233,11 +230,11 @@ fn main() {
                     print_nothing_or_fail(result);
                 }
                 ("publish", "message") => {
-                    let result = commands::publish_message(client, &sf.virtual_host, command_args);
+                    let result = commands::publish_message(client, &vhost, command_args);
                     print_result_or_fail(result);
                 }
                 ("get", "messages") => {
-                    let result = commands::get_messages(client, &sf.virtual_host, command_args);
+                    let result = commands::get_messages(client, &vhost, command_args);
                     print_table_or_fail(result);
                 }
                 _ => {
@@ -246,6 +243,27 @@ fn main() {
                 }
             }
         }
+    }
+}
+
+/// Retrieves a --vhost value, either from global or command-specific arguments
+fn virtual_host(global_flags: &SharedFlags, command_flags: &ArgMatches) -> String {
+    // in case a command does not define --vhost
+    if let Ok(_) = command_flags.try_contains_id("vhost") {
+        // if the command-specific flag is not set to default,
+        // use it, otherwise use the global/shared --vhost flag value
+        let fallback = String::from(DEFAULT_VHOST);
+        let command_vhost: &str = command_flags
+            .get_one::<String>("vhost")
+            .unwrap_or(&fallback);
+
+        if command_vhost != DEFAULT_VHOST {
+            String::from(command_vhost)
+        } else {
+            global_flags.virtual_host.clone()
+        }
+    } else {
+        global_flags.virtual_host.clone()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,7 @@ fn main() {
 /// Retrieves a --vhost value, either from global or command-specific arguments
 fn virtual_host(global_flags: &SharedFlags, command_flags: &ArgMatches) -> String {
     // in case a command does not define --vhost
-    if let Ok(_) = command_flags.try_contains_id("vhost") {
+    if command_flags.try_contains_id("vhost").is_ok() {
         // if the command-specific flag is not set to default,
         // use it, otherwise use the global/shared --vhost flag value
         let fallback = String::from(DEFAULT_VHOST);


### PR DESCRIPTION
to make it possible to specify it at the end of
command invocation.

This solution would not work for every flag but
--vhost should be the most common shared one.