### PR TITLE
One line per item in non-interactive output

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -25,8 +25,12 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use sysexits::ExitCode;
 use tabled::settings::object::Rows;
+
 use tabled::settings::{Panel, Remove, Style};
-use tabled::{Table, Tabled};
+use tabled::{
+    Table, Tabled,
+    settings::{Format, Modify, object::Segment},
+};
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TableStyle {
@@ -111,7 +115,9 @@ impl TableStyler {
 
     fn apply_borderless(self, table: &mut Table) -> &Table {
         table.with(Style::empty());
-        table.with(Remove::row(Rows::first()))
+        table.with(tabled::settings::Padding::new(0, 1, 0, 0));
+        table.with(Remove::row(Rows::first()));
+        table.with(Modify::new(Segment::all()).with(Format::content(|s| s.replace("\n", ","))))
     }
 
     fn apply_markdown(self, table: &mut Table) -> &Table {


### PR DESCRIPTION
Before - multiple lines and a space as the first character of the row/line:
```
$ rabbitmqadmin --non-interactive list queues
 qq  /  quorum  true  false  false  x-queue-type: "quorum"  rabbit-1@K6L59PF0JR  running  rabbit-1@K6L59PF0JR  rabbit-1@K6L59PF0JR  rabbit-1@K6L59PF0JR  26844  0  0    0  0  0 
                                                                                                               rabbit-2@K6L59PF0JR  rabbit-2@K6L59PF0JR                         
                                                                                                               rabbit-3@K6L59PF0JR  rabbit-3@K6L59PF0JR          
```

With this PR:
```
qq / quorum true false false x-queue-type: "quorum", rabbit-1@K6L59PF0JR running rabbit-1@K6L59PF0JR rabbit-1@K6L59PF0JR,rabbit-2@K6L59PF0JR,rabbit-3@K6L59PF0JR rabbit-1@K6L59PF0JR,rabbit-2@K6L59PF0JR,rabbit-3@K6L59PF0JR 29860 0 0  0 0 0
```

This enables common shell scripting techniques, eg:
```
$ rabbitmqadmin --non-interactive list queues | cut -w -f 1
qq1
qq2
qq3
```