### PR TITLE
'definitions export': introduce --transformations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,12 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -296,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -308,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -957,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1199,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "openssl"
@@ -1311,11 +1305,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1452,8 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "rabbitmq_http_client"
-version = "0.26.0"
-source = "git+https://github.com/michaelklishin/rabbitmq-http-api-rs.git#facfc2e575921189dc4589e04a11f2df13e05001"
+version = "0.27.0"
 dependencies = [
  "backtrace",
  "percent-encoding",
@@ -1512,7 +1505,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1676,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1721,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
  "bitflags",
  "errno",
@@ -1849,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -1880,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,9 +1975,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2071,7 +2064,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix 1.0.0",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2179,9 +2172,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2755,32 +2748,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.23",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
 [[package]]
 name = "rabbitmq_http_client"
 version = "0.27.0"
+source = "git+https://github.com/michaelklishin/rabbitmq-http-api-rs.git#045d0b1c7a21379d85b45c2b61304d82c1c6510b"
 dependencies = [
  "backtrace",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.12.12", features = [
     "__rustls",
     "rustls-tls-native-roots"
 ]}
-rabbitmq_http_client = { path = "/Users/antares/Development/RabbitMQ/rabbitmq-http-api-client-rs.git", features = [
+rabbitmq_http_client = { git = "https://github.com/michaelklishin/rabbitmq-http-api-rs.git", features = [
     "core",
     "blocking",
     "tabled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.12.12", features = [
     "__rustls",
     "rustls-tls-native-roots"
 ]}
-rabbitmq_http_client = { git = "https://github.com/michaelklishin/rabbitmq-http-api-rs.git", features = [
+rabbitmq_http_client = { path = "/Users/antares/Development/RabbitMQ/rabbitmq-http-api-client-rs.git", features = [
     "core",
     "blocking",
     "tabled"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use super::constants::*;
 use super::static_urls::*;
 use super::tanzu_cli::tanzu_subcommands;
 use crate::output::TableStyle;
-use clap::{Arg, ArgAction, ArgGroup, Command, value_parser};
+use clap::{value_parser, Arg, ArgAction, ArgGroup, Command};
 use rabbitmq_http_client::commons::{
     BindingDestinationType, ExchangeType, PolicyTarget, QueueType, ShovelAcknowledgementMode,
     SupportedProtocol,
@@ -1187,6 +1187,20 @@ fn definitions_subcommands() -> [Command; 4] {
                 .help("output file path or '-' for standard output")
                 .required(false)
                 .default_value("-"),
+        )
+        .arg(
+            Arg::new("transformations")
+                .long("transformations")
+                .short('t')
+                .long_help(r#"
+Comma-separated names of the transformations to apply to the definitions.
+
+Supported names: strip_cmq_policies"
+                "#)
+                .num_args(1..)
+                .value_delimiter(',')
+                .action(ArgAction::Append)
+                .required(false),
         );
 
     let export_from_vhost_cmd = Command::new("export_from_vhost")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use super::constants::*;
 use super::static_urls::*;
 use super::tanzu_cli::tanzu_subcommands;
 use crate::output::TableStyle;
-use clap::{value_parser, Arg, ArgAction, ArgGroup, Command};
+use clap::{Arg, ArgAction, ArgGroup, Command, value_parser};
 use rabbitmq_http_client::commons::{
     BindingDestinationType, ExchangeType, PolicyTarget, QueueType, ShovelAcknowledgementMode,
     SupportedProtocol,
@@ -1192,11 +1192,13 @@ fn definitions_subcommands() -> [Command; 4] {
             Arg::new("transformations")
                 .long("transformations")
                 .short('t')
-                .long_help(r#"
+                .long_help(
+                    r#"
 Comma-separated names of the transformations to apply to the definitions.
 
 Supported names: strip_cmq_policies"
-                "#)
+                "#,
+                )
                 .num_args(1..)
                 .value_delimiter(',')
                 .action(ArgAction::Append)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -21,8 +21,8 @@ use rabbitmq_http_client::commons::{ExchangeType, SupportedProtocol};
 use rabbitmq_http_client::commons::{PolicyTarget, VirtualHostLimitTarget};
 use rabbitmq_http_client::commons::{ShovelAcknowledgementMode, UserLimitTarget};
 use rabbitmq_http_client::requests::{
-    Amqp091ShovelDestinationParams, Amqp091ShovelParams, Amqp091ShovelSourceParams,
     Amqp10ShovelDestinationParams, Amqp10ShovelParams, Amqp10ShovelSourceParams,
+    Amqp091ShovelDestinationParams, Amqp091ShovelParams, Amqp091ShovelSourceParams,
     EnforcedLimitParams,
 };
 use std::fs;
@@ -918,7 +918,7 @@ pub fn export_cluster_wide_definitions(
     } else {
         let transformations = transformations
             .into_iter()
-            .map(|t| String::from(t))
+            .map(String::from)
             .collect::<Vec<_>>();
         export_and_transform_cluster_wide_definitions(client, command_args, transformations)
     }


### PR DESCRIPTION
these named functions can help a variety
of RabbitMQ operation tasks, from obfuscating
values to stripping off deprecated or removed
keys from policies, to enforcing a default
queue type during upgrades from older series
that do not support DQT.
