### PR TITLE
Add `repository` to project configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rabbitmqadmin"
 version = "2.19.0"
 edition = "2024"
-
+repository = "https://github.com/rabbitmq/rabbitmqadmin-ng"
 description = "rabbitmqadmin v2 is a modern CLI tool for the RabbitMQ HTTP API"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
By adding `repository`, future releases can be installed via `cargo binstall rabbitmqadmin`