### PR TITLE
Add `--verbose` flag to log HTTP requests and responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 profile.json
 .tool-versions
 *.proptest-regressions
+tests/proptest-regressions/
 tests/tls/certs/*.pem
 tests/tls/certs/*.conf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1515,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "color-print",
+ "fern",
  "indicatif",
  "log",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clap_complete_nushell = "4.6"
 
 log = "0.4"
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
-# fern = "0.7"
+fern = "0.7"
 # humantime = "2.1.0"
 # backtrace = "0.3"
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -618,6 +618,19 @@ pub fn parser(pre_flight_settings: PreFlightSettings) -> Command {
                 .env("RABBITMQADMIN_QUIET_MODE")
                 .help("produce less output")
                 .required(false)
+                .conflicts_with("verbose")
+                .value_parser(value_parser!(bool))
+                .action(ArgAction::SetTrue),
+        )
+        // --verbose
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .env("RABBITMQADMIN_VERBOSE")
+                .help("enable verbose logging of HTTP requests and responses")
+                .required(false)
+                .conflicts_with("quiet")
                 .value_parser(value_parser!(bool))
                 .action(ArgAction::SetTrue),
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,8 @@ pub struct SharedSettings {
     pub non_interactive: bool,
     #[serde(default = "default_quiet")]
     pub quiet: bool,
+    #[serde(default = "default_verbose")]
+    pub verbose: bool,
 
     #[serde(default)]
     pub scheme: Scheme,
@@ -237,6 +239,11 @@ impl SharedSettings {
             || config_file_defaults.non_interactive;
         let quiet = cli_args.get_one::<bool>("quiet").cloned().unwrap_or(false)
             || config_file_defaults.quiet;
+        let verbose = cli_args
+            .get_one::<bool>("verbose")
+            .cloned()
+            .unwrap_or(false)
+            || config_file_defaults.verbose;
         let scheme = if should_use_tls {
             Scheme::Https
         } else {
@@ -308,6 +315,7 @@ impl SharedSettings {
 
             non_interactive,
             quiet,
+            verbose,
             base_uri: None,
             scheme,
             hostname: Some(hostname),
@@ -329,6 +337,11 @@ impl SharedSettings {
             .unwrap_or(false)
             || default_non_interactive();
         let quiet = cli_args.get_one::<bool>("quiet").cloned().unwrap_or(false) || default_quiet();
+        let verbose = cli_args
+            .get_one::<bool>("verbose")
+            .cloned()
+            .unwrap_or(false)
+            || default_verbose();
         let scheme = if should_use_tls {
             Scheme::Https
         } else {
@@ -391,6 +404,7 @@ impl SharedSettings {
 
             non_interactive,
             quiet,
+            verbose,
             base_uri: None,
             scheme,
             hostname: Some(hostname),
@@ -418,6 +432,11 @@ impl SharedSettings {
             || config_file_defaults.non_interactive;
         let quiet = cli_args.get_one::<bool>("quiet").cloned().unwrap_or(false)
             || config_file_defaults.quiet;
+        let verbose = cli_args
+            .get_one::<bool>("verbose")
+            .cloned()
+            .unwrap_or(false)
+            || config_file_defaults.verbose;
 
         let scheme = if should_use_tls {
             Scheme::Https
@@ -481,6 +500,7 @@ impl SharedSettings {
 
             non_interactive,
             quiet,
+            verbose,
             base_uri: Some(url.to_string()),
             scheme,
             hostname: Some(hostname),
@@ -504,6 +524,10 @@ impl SharedSettings {
             .get_one::<bool>("quiet")
             .cloned()
             .unwrap_or(default_quiet());
+        let verbose = cli_args
+            .get_one::<bool>("verbose")
+            .cloned()
+            .unwrap_or(default_verbose());
 
         let scheme = if should_use_tls {
             Scheme::Https
@@ -563,6 +587,7 @@ impl SharedSettings {
 
             non_interactive,
             quiet,
+            verbose,
             base_uri: Some(url.to_string()),
             scheme,
             hostname: Some(hostname),
@@ -617,6 +642,10 @@ fn default_non_interactive() -> bool {
 }
 
 fn default_quiet() -> bool {
+    false
+}
+
+fn default_verbose() -> bool {
     false
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,12 @@ fn main() -> ExitCode {
         Err(code) => return code,
     };
 
+    if common_settings.verbose
+        && let Err(e) = init_verbose_logging()
+    {
+        eprintln!("Warning: failed to initialize verbose logging: {e}");
+    }
+
     match configure_http_api_client(&cli, &common_settings, &endpoint.clone()) {
         Ok(client) => dispatch_command(&cli, client, &common_settings),
         Err(err) => {
@@ -487,4 +493,16 @@ fn virtual_host(shared_settings: &SharedSettings, command_flags: &ArgMatches) ->
         .virtual_host
         .clone()
         .unwrap_or_else(|| DEFAULT_VHOST.to_string())
+}
+
+fn init_verbose_logging() -> Result<(), fern::InitError> {
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!("[{}] {}", record.target(), message))
+        })
+        .level(log::LevelFilter::Off)
+        .level_for("rabbitmq_http_client", log::LevelFilter::Trace)
+        .chain(std::io::stderr())
+        .apply()?;
+    Ok(())
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,6 +52,7 @@ mod timeout_tests;
 mod tls_tests;
 mod user_limits_tests;
 mod users_tests;
+mod verbose_tests;
 mod vhost_limits_tests;
 mod vhosts_delete_multiple_tests;
 mod vhosts_tests;

--- a/tests/integration/verbose_tests.rs
+++ b/tests/integration/verbose_tests.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2023-2026 RabbitMQ Core Team (teamrabbitmq@gmail.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::test_helpers::{output_includes, run_fails, run_succeeds};
+use std::error::Error;
+
+#[test]
+fn test_verbose_logs_http_method_and_url_to_stderr() -> Result<(), Box<dyn Error>> {
+    run_succeeds(["--verbose", "vhosts", "list"]).stderr(output_includes(
+        "HTTP GET: http://localhost:15672/api/vhosts",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn test_verbose_and_quiet_are_mutually_exclusive() -> Result<(), Box<dyn Error>> {
+    run_fails(["--verbose", "--quiet", "vhosts", "list"])
+        .stderr(output_includes("cannot be used with"));
+
+    Ok(())
+}

--- a/tests/proptests/config_proptests.rs
+++ b/tests/proptests/config_proptests.rs
@@ -122,6 +122,7 @@ proptest! {
             tls: scheme.is_https(),
             non_interactive: false,
             quiet: false,
+            verbose: false,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -156,6 +157,7 @@ proptest! {
             tls: scheme.is_https(),
             non_interactive: false,
             quiet: false,
+            verbose: false,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -190,6 +192,7 @@ proptest! {
             tls: scheme.is_https(),
             non_interactive: false,
             quiet: false,
+            verbose: false,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -235,6 +238,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -267,6 +271,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -317,6 +322,11 @@ fn create_test_parser() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(Arg::new("quiet").long("quiet").action(ArgAction::SetTrue))
+        .arg(
+            Arg::new("verbose")
+                .long("verbose")
+                .action(ArgAction::SetTrue),
+        )
         .arg(Arg::new("path_prefix").long("path-prefix"))
         .arg(Arg::new("base_uri").long("base-uri"))
         .arg(Arg::new("table_style").long("table-style"))
@@ -366,6 +376,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
@@ -403,6 +414,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             password: Some("guest".to_string()),
             virtual_host: Some("/".to_string()),
@@ -441,6 +453,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
@@ -480,6 +493,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
@@ -526,6 +540,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             username: Some("config_user".to_string()),
             password: Some("config_pass".to_string()),
@@ -571,6 +586,7 @@ proptest! {
             tls: false,
             non_interactive: false,
             quiet: false,
+            verbose: false,
             base_uri: None,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),
@@ -618,6 +634,7 @@ proptest! {
             tls: false,
             non_interactive: config_non_interactive,
             quiet: config_quiet,
+            verbose: false,
             base_uri: None,
             username: Some("guest".to_string()),
             password: Some("guest".to_string()),


### PR DESCRIPTION
Implements the `--verbose` / `-v` flag requested in #51.

## What it does

When `--verbose` is passed, HTTP request details are logged to stderr for every API call:

- Method and URL for all requests
- Pretty-printed request body for PUT and POST requests

Example output:

```
$ rabbitmqadmin --verbose vhosts declare --name my-vhost
[rabbitmq_http_client::blocking_api::client] HTTP PUT: http://localhost:15672/api/vhosts/my%2Dvhost
Request body:
{
  "name": "my-vhost",
  "tracing": false
}
```

## Implementation

The `rabbitmq_http_client` library already emits `trace!()` log calls for every HTTP request (method, URL, and body). This PR wires up a `fern` logger scoped to the `rabbitmq_http_client` target at `Trace` level, writing to stderr, when `--verbose` is set.

No changes to the library were needed.

## Notes

- `--verbose` and `--quiet` are mutually exclusive
- The flag can also be set via the `RABBITMQADMIN_VERBOSE` environment variable
- Verbose output goes to stderr; normal command output continues on stdout

Closes #51
