### PR TITLE
Help text fixes & cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ or a container that uses the [community OCI image](https://github.com/docker-lib
 Install [cargo-nextest](https://nexte.st/):
 
 ```bash
-cargo install cargo-nextest
+cargo install --locked cargo-nextest
 ```
 
 ### Step 1: Start RabbitMQ

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2035,7 +2035,7 @@ fn operator_policies_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<
         .arg(
             Arg::new("name")
                 .long("name")
-                .help("policy name")
+                .help("operator policy name")
                 .required(true),
         )
         .arg(idempotently_arg.clone());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3990,7 +3990,7 @@ pub fn shovel_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             SHOVEL_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/shovel#tls-connections"
+            SHOVEL_TLS_GUIDE_URL
         ));
 
     let disable_tls_peer_verification_dest_cmd = Command::new("disable_tls_peer_verification_for_all_destination_uris")
@@ -4004,7 +4004,7 @@ pub fn shovel_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             SHOVEL_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/shovel#tls-connections"
+            SHOVEL_TLS_GUIDE_URL
         ));
 
     let enable_tls_peer_verification_source_cmd = Command::new("enable_tls_peer_verification_for_all_source_uris")
@@ -4039,7 +4039,7 @@ pub fn shovel_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             SHOVEL_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/shovel#tls-connections"
+            SHOVEL_TLS_GUIDE_URL
         ));
 
     let enable_tls_peer_verification_dest_cmd = Command::new("enable_tls_peer_verification_for_all_destination_uris")
@@ -4074,7 +4074,7 @@ pub fn shovel_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             SHOVEL_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/shovel#tls-connections"
+            SHOVEL_TLS_GUIDE_URL
         ));
 
     [
@@ -4444,7 +4444,7 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             FEDERATION_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/federation#tls-connections"
+            FEDERATION_TLS_GUIDE_URL
         ));
 
     let enable_tls_peer_verification_cmd = Command::new("enable_tls_peer_verification_for_all_upstreams")
@@ -4479,7 +4479,7 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
  * {}"#,
             FEDERATION_GUIDE_URL,
             TLS_GUIDE_URL,
-            "https://www.rabbitmq.com/docs/federation#tls-connections"
+            FEDERATION_TLS_GUIDE_URL
         ));
 
     [

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -912,7 +912,7 @@ fn declare_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
                 .help("should tracing be enabled for this virtual host?"),
         );
     let permissions_cmd = Command::new("permissions")
-        .about("grants permissions to a user")
+        .about("Grants permissions to a user")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             ACCESS_CONTROL_GUIDE_URL
@@ -1184,7 +1184,7 @@ fn declare_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
                 .required(true),
         );
     let vhost_limit_cmd = Command::new("vhost_limit")
-        .about("Set a vhost limit")
+        .about("Sets a vhost limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             VIRTUAL_HOST_LIMIT_GUIDE_URL
@@ -1202,7 +1202,7 @@ fn declare_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
                 .required(true),
         );
     let user_limit_cmd = Command::new("user_limit")
-        .about("Set a user limit")
+        .about("Sets a user limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             USER_LIMIT_GUIDE_URL
@@ -1421,7 +1421,7 @@ fn delete_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
         )
         .arg(idempotently_arg.clone());
     let vhost_limit_cmd = Command::new("vhost_limit")
-        .about("delete a vhost limit")
+        .about("Deletes a vhost limit")
         .arg(
             Arg::new("name")
                 .long("name")
@@ -1444,7 +1444,7 @@ fn delete_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
                 .required(true),
         );
     let shovel_cmd = Command::new("shovel")
-        .about("Delete a shovel")
+        .about("Deletes a shovel")
         .arg(idempotently_arg.clone())
         .arg(
             Arg::new("name")
@@ -2754,7 +2754,7 @@ fn config_file_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Comman
 
 fn definitions_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
     let export_cmd = Command::new("export")
-        .about("Export cluster-wide definitions")
+        .about("Exports cluster-wide definitions")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL
@@ -2817,7 +2817,7 @@ Examples:
         );
 
     let export_from_vhost_cmd = Command::new("export_from_vhost")
-        .about("Export definitions of a specific virtual host")
+        .about("Exports definitions of a specific virtual host")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL
@@ -2872,7 +2872,7 @@ Examples:
         );
 
     let import_cmd = Command::new("import")
-        .about("Import cluster-wide definitions (of multiple virtual hosts)")
+        .about("Imports cluster-wide definitions (of multiple virtual hosts)")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL
@@ -2897,7 +2897,7 @@ Examples:
         );
 
     let import_into_vhost_cmd = Command::new("import_into_vhost")
-        .about("Import a virtual host-specific definitions file into a virtual host")
+        .about("Imports a virtual host-specific definitions file into a virtual host")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL
@@ -3065,7 +3065,7 @@ fn exchanges_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command>
 }
 fn export_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
     let definitions = Command::new("definitions")
-        .about("Export cluster-wide definitions")
+        .about("Exports cluster-wide definitions")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL
@@ -3640,7 +3640,7 @@ pub fn user_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Co
         );
 
     let declare_cmd = Command::new("declare")
-        .about("Set a user limit")
+        .about("Sets a user limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             USER_LIMIT_GUIDE_URL
@@ -3696,7 +3696,7 @@ pub fn vhost_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<C
         ));
 
     let declare_cmd = Command::new("declare")
-        .about("Set a vhost limit")
+        .about("Sets a vhost limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             VIRTUAL_HOST_LIMIT_GUIDE_URL
@@ -3714,7 +3714,7 @@ pub fn vhost_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<C
                 .required(true),
         );
 
-    let delete_cmd = Command::new("delete").about("delete a vhost limit").arg(
+    let delete_cmd = Command::new("delete").about("Clears a vhost limit").arg(
         Arg::new("name")
             .long("name")
             .help("limit name (eg. max-connections, max-queues)")
@@ -4411,7 +4411,7 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
         .arg(idempotently_arg.clone());
 
     let list_all_links = Command::new("list_all_links")
-        .long_about("List federation links in all virtual hosts")
+        .long_about("Lists federation links in all virtual hosts")
         .after_help(color_print::cformat!(
             r#"<bold>Doc guides</bold>:
 
@@ -4494,7 +4494,7 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
 
 fn shell_subcommands() -> Vec<Command> {
     let completions_cmd = Command::new("completions")
-        .about("Generate shell completion scripts for the CLI")
+        .about("Generates shell completion scripts for the CLI")
         .long_about(
             "Generates shell completion scripts for bash, zsh, fish, elvish, or nushell.\n\n\
              If --shell is not specified, the shell is detected from the SHELL environment variable.\n\

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3714,12 +3714,14 @@ pub fn vhost_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<C
                 .required(true),
         );
 
-    let delete_cmd = Command::new("delete").about("Clears a vhost limit").arg(
-        Arg::new("name")
-            .long("name")
-            .help("limit name (eg. max-connections, max-queues)")
-            .required(true),
-    );
+    let delete_cmd = Command::new("delete")
+        .about("Clears a vhost limit")
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .help("limit name (eg. max-connections, max-queues)")
+                .required(true),
+        );
 
     [list_cmd, declare_cmd, delete_cmd]
         .into_iter()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3743,7 +3743,7 @@ pub fn publish_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Comman
                 .long("routing-key")
                 .required(false)
                 .default_value("")
-                .help("Routing key (defaults to empty)"),
+                .help("Routing key"),
         )
         .arg(
             Arg::new("exchange")
@@ -3751,7 +3751,7 @@ pub fn publish_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Comman
                 .long("exchange")
                 .required(false)
                 .default_value("")
-                .help("Exchange name (defaults to empty)"),
+                .help("Exchange name"),
         )
         .arg(
             Arg::new("payload")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -174,7 +174,7 @@ pub fn parser(pre_flight_settings: PreFlightSettings) -> Command {
         .arg_required_else_help(true)
         .subcommands(federation_subcommands(pre_flight_settings.clone()));
     let get_group = Command::new("get")
-        .about(color_print::cstr!("Fetches message(s) from a queue or stream via <bold><red>polling</red></bold>. <bold><red>Only suitable for development and test environments</red></bold>."))
+        .about(color_print::cstr!("Fetches message(s) from a queue via <bold><red>polling</red></bold>. <bold>Unavailable for streams. <red>Only suitable for development and test environments</red></bold>."))
         .infer_subcommands(pre_flight_settings.infer_subcommands)
         .infer_long_args(pre_flight_settings.infer_long_options)
         .after_help(color_print::cformat!("<bold>Doc guide</bold>: {}", POLLING_CONSUMER_GUIDE_URL))
@@ -3790,14 +3790,14 @@ pub fn publish_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Comman
 
 pub fn get_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
     [Command::new("messages")
-        .about(color_print::cstr!("Fetches (via <red>polling, very inefficiently</red>) message(s) from a queue. <bold><red>Only suitable for development and test environments</red></bold>"))
+        .about(color_print::cstr!("Fetches (via <red>polling, very inefficiently</red>) message(s) from a queue. <bold>Not available for streams</bold>. <bold><red>Only suitable for development and test environments</red></bold>"))
         .after_help(color_print::cformat!("<bold>Doc guide</bold>: {}", POLLING_CONSUMER_GUIDE_URL))
         .arg(
             Arg::new("queue")
                 .short('q')
                 .long("queue")
                 .required(true)
-                .help("Target queue or stream name"),
+                .help("Target queue name"),
         )
         .arg(
             Arg::new("count")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2058,7 +2058,7 @@ fn operator_policies_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<
         );
 
     let delete_definition_key_from_all_in_cmd = Command::new("delete_definition_keys_from_all_in")
-        .about("Deletes a definition key from all operator policies in a virtual host, unless it is the only key")
+        .about("Deletes definition keys from all operator policies in a virtual host, unless it is the only key")
         .arg(
             Arg::new("definition_keys")
                 .long("definition-keys")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3737,7 +3737,7 @@ pub fn publish_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Comman
                 .long("routing-key")
                 .required(false)
                 .default_value("")
-                .help("Name of virtual host"),
+                .help("Routing key (defaults to empty)"),
         )
         .arg(
             Arg::new("exchange")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1188,7 +1188,7 @@ fn declare_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
                 .required(true),
         );
     let vhost_limit_cmd = Command::new("vhost_limit")
-        .about("Sets a vhost limit")
+        .about("Sets a virtual host limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             VIRTUAL_HOST_LIMIT_GUIDE_URL
@@ -1320,7 +1320,7 @@ fn delete_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
         )
         .arg(idempotently_arg.clone());
     let permissions_cmd = Command::new("permissions")
-        .about("Revokes user permissions to a given vhost")
+        .about("Revokes user permissions to a given virtual host")
         .arg(
             Arg::new("username")
                 .long("username")
@@ -1425,7 +1425,7 @@ fn delete_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
         )
         .arg(idempotently_arg.clone());
     let vhost_limit_cmd = Command::new("vhost_limit")
-        .about("Deletes a vhost limit")
+        .about("Deletes a virtual host limit")
         .arg(
             Arg::new("name")
                 .long("name")
@@ -3612,7 +3612,7 @@ pub fn permissions_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Co
         );
 
     let delete_cmd = Command::new("delete")
-        .about("Revokes user permissions to a given vhost")
+        .about("Revokes user permissions to a given virtual host")
         .arg(
             Arg::new("username")
                 .long("username")
@@ -3700,7 +3700,7 @@ pub fn vhost_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<C
         ));
 
     let declare_cmd = Command::new("declare")
-        .about("Sets a vhost limit")
+        .about("Sets a virtual host limit")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             VIRTUAL_HOST_LIMIT_GUIDE_URL
@@ -3719,7 +3719,7 @@ pub fn vhost_limits_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<C
         );
 
     let delete_cmd = Command::new("delete")
-        .about("Clears a vhost limit")
+        .about("Clears a virtual host limit")
         .arg(
             Arg::new("name")
                 .long("name")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -225,7 +225,7 @@ pub fn parser(pre_flight_settings: PreFlightSettings) -> Command {
         .arg_required_else_help(true)
         .subcommands(list_subcommands(pre_flight_settings.clone()));
     let nodes_group = Command::new("nodes")
-        .about("Node operations")
+        .about("Operations on nodes")
         .infer_subcommands(pre_flight_settings.infer_subcommands)
         .infer_long_args(pre_flight_settings.infer_long_options)
         .arg_required_else_help(true)
@@ -274,7 +274,7 @@ pub fn parser(pre_flight_settings: PreFlightSettings) -> Command {
         .arg_required_else_help(true)
         .subcommands(permissions_subcommands(pre_flight_settings.clone()));
     let plugins_group = Command::new("plugins")
-        .about("List enabled plugins")
+        .about("Lists enabled plugins")
         .infer_subcommands(pre_flight_settings.infer_subcommands)
         .infer_long_args(pre_flight_settings.infer_long_options)
         .after_help(color_print::cformat!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -691,7 +691,11 @@ fn columns_arg() -> Arg {
 }
 
 fn list_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
-    let nodes_cmd = Command::new("nodes").long_about("Lists cluster members");
+    let nodes_cmd = Command::new("nodes").long_about("Lists cluster nodes")
+        .after_help(color_print::cformat!(
+            "<bold>Doc guide</bold>: {}",
+            CLUSTERING_GUIDE_URL
+        ));
     let vhosts_cmd = Command::new("vhosts")
         .long_about("Lists virtual hosts")
         .after_help(color_print::cformat!(
@@ -712,7 +716,7 @@ fn list_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
         ))
         .args(pagination_args());
     let channels_cmd = Command::new("channels")
-        .long_about("Lists AMQP 0-9-1 channels")
+        .long_about("Lists all AMQP 0-9-1 channels across all virtual hosts")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             CHANNEL_GUIDE_URL
@@ -2541,10 +2545,10 @@ fn close_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
 
 fn channels_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
     let list_cmd = Command::new("list")
-        .long_about("Lists all channels across all virtual hosts")
+        .long_about("Lists all AMQP 0-9-1 channels across all virtual hosts")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
-            "https://www.rabbitmq.com/docs/channels"
+            CHANNEL_GUIDE_URL
         ))
         .args(pagination_args());
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -807,7 +807,7 @@ fn list_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
             DEPRECATED_FEATURE_GUIDE_URL
         ));
     let deprecated_features_in_use_cmd = Command::new("deprecated_features_in_use")
-        .long_about("Lists the deprecated features that are in used in the cluster")
+        .long_about("Lists the deprecated features that are currently in use in the cluster")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEPRECATED_FEATURE_GUIDE_URL

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4160,7 +4160,6 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
                 .default_value("1000")
                 .value_parser(value_parser!(u32))
                 .help("The prefetch value to use with internal consumers")
-                .value_parser(value_parser!(u32))
         )
         .arg(
             Arg::new("ack_mode")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -575,7 +575,7 @@ pub fn parser(pre_flight_settings: PreFlightSettings) -> Command {
         .arg(
             Arg::new("tls")
                 .long("use-tls")
-                .help("use TLS (HTTPS) for HTTP API requests ")
+                .help("use TLS (HTTPS) for HTTP API requests")
                 .env("RABBITMQADMIN_USE_TLS")
                 .value_parser(value_parser!(bool))
                 .action(ArgAction::SetTrue),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4397,7 +4397,7 @@ fn federation_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command
         );
 
     let delete_upstream = Command::new("delete_upstream")
-        .long_about("Declares a federation upstream")
+        .long_about("Deletes a federation upstream")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             FEDERATION_GUIDE_URL

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3069,7 +3069,7 @@ fn exchanges_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command>
 }
 fn export_subcommands(pre_flight_settings: PreFlightSettings) -> Vec<Command> {
     let definitions = Command::new("definitions")
-        .about("Exports cluster-wide definitions")
+        .about("Prefer 'definitions export'")
         .after_help(color_print::cformat!(
             "<bold>Doc guide</bold>: {}",
             DEFINITION_GUIDE_URL

--- a/src/static_urls.rs
+++ b/src/static_urls.rs
@@ -62,7 +62,11 @@ pub(crate) const USER_LIMIT_GUIDE_URL: &str = "https://rabbitmq.com/docs/user-li
 pub(crate) const PASSWORD_GUIDE_URL: &str = "https://rabbitmq.com/docs/passwords";
 pub(crate) const PLUGIN_GUIDE_URL: &str = "https://rabbitmq.com/docs/plugins";
 pub(crate) const SHOVEL_GUIDE_URL: &str = "https://rabbitmq.com/docs/shovel";
+pub(crate) const SHOVEL_TLS_GUIDE_URL: &str =
+    "https://www.rabbitmq.com/docs/shovel#tls-connections";
 pub(crate) const FEDERATION_GUIDE_URL: &str = "https://rabbitmq.com/docs/federation";
+pub(crate) const FEDERATION_TLS_GUIDE_URL: &str =
+    "https://www.rabbitmq.com/docs/federation#tls-connections";
 pub(crate) const FEDERATED_QUEUES_GUIDE_URL: &str = "https://rabbitmq.com/docs/federated-queues";
 pub(crate) const FEDERATED_EXCHANGES_GUIDE_URL: &str =
     "https://rabbitmq.com/docs/federated-exchanges";


### PR DESCRIPTION
Some help texts were missing context, had typos, differed between cli branches, or simply had a different writing style. In a few cases, some were incorrect. This PR tries to address all those at onces.

+ a minor change in the CONTRIBUTING.md to reflect nextest requiring to be installed with --locked.

This should overall not affect functionality at all.