### PR TITLE
Bump RabbitMQ HTTP API client to `0.92.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## v2.35.0 (in development)
 
-No changes yet.
+### Enhancements
+
+ * Forward compatibility with RabbitMQ `4.4.0` ([`rabbitmq/rabbitmq-server#17316`](https://github.com/rabbitmq/rabbitmq-server/pull/17316))
+
+### Dependencies
+
+ * `rabbitmq_http_client` upgraded to `0.91.0`
 
 
 ## v2.34.0 (Aug 19, 2026)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rabbitmq_http_client"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb7332d32381add26c217c7b4726b6a2b91f8308091b4a12a01c614c2c37771"
+checksum = "192e5766214e54f9da22528e204858817675b47409de0033a325c224a76998d5"
 dependencies = [
  "backtrace",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "http2",
     "charset",
 ] }
-rabbitmq_http_client = { version = "0.91", default-features = false, features = [
+rabbitmq_http_client = { version = "0.92", default-features = false, features = [
     "blocking",
     "tabled",
     "rustls",


### PR DESCRIPTION
See https://github.com/rabbitmq/rabbitmq-server/pull/17316.